### PR TITLE
ump dependency for openclean-notebook to 0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,8 @@
 ### 0.2.0 - 2021-06-15
 
 * Adjustments for running external tools using flowserv 0.9.0.
+
+
+### 0.2.1 - 2021-08-15
+
+* Bump dependency for openclean-notebook to 0.1.7 (\#6).

--- a/README.rst
+++ b/README.rst
@@ -71,8 +71,8 @@ Usage
 
 We include several example notebooks in this repository that demonstrate possible use cases for **openclean**. We recommend starting with the `documentation <http://openclean.readthedocs.io/>`_ or the New York City Restaurant Inspection Results notebook. In that example our goal is to reproduce a previous `study from 2014 that looks at the distribution of restaurant inspection grades in New York City <https://iquantny.tumblr.com/post/76928412519/think-nyc-restaurant-grading-is-flawed-heres>`_. For our study, we use data that was downloaded in Sept. 2019. The example is split into two different Jupyter notebooks:
 
-- `Data Profiling <https://github.com/VIDA-NYU/openclean-core/blob/master/examples/notebooks/NYCRestaurantInspections/NYC%20Restaurant%20Inspections%20-%20Profiling.ipynb>`_
-- `Data Cleaning <https://github.com/VIDA-NYU/openclean-core/blob/master/examples/notebooks/NYCRestaurantInspections/NYC%20Restaurant%20Inspections%20-%20Cleaning.ipynb>`_
+- `Data Profiling <https://github.com/VIDA-NYU/openclean-core/blob/master/examples/notebooks/nyc-restaurant-inspections/NYC%20Restaurant%20Inspections%20-%20Profiling.ipynb>`_
+- `Data Cleaning <https://github.com/VIDA-NYU/openclean-core/blob/master/examples/notebooks/nyc-restaurant-inspections/NYC%20Restaurant%20Inspections%20-%20Cleaning.ipynb>`_
 
 Other examples along with the datasets are located in `the examples' folder <https://github.com/VIDA-NYU/openclean-core/tree/master/examples/notebooks>`_
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 openclean-core==0.4.1
 openclean-geo==0.1.0
 openclean-metanome==0.2.0
-openclean-notebook==0.1.5
+openclean-notebook==0.1.7
 openclean-pattern==0.0.1
 docker
 jupyter

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ docker_requires = ['docker']
 
 geo_requires = ['openclean-geo==0.1.0']
 metanome_requires = ['openclean-metanome==0.2.0']
-notebook_requires = ['openclean-notebook==0.1.5']
+notebook_requires = ['openclean-notebook==0.1.7']
 pattern_requires = ['openclean-pattern==0.0.1']
 openclean_extension = geo_requires + metanome_requires + notebook_requires + pattern_requires
 
@@ -41,7 +41,7 @@ with open('README.rst', 'rt') as f:
 
 setup(
     name='openclean',
-    version='0.2.0',
+    version='0.2.1',
     description='Library for data cleaning and data profiling',
     long_description=readme,
     long_description_content_type='text/x-rst',


### PR DESCRIPTION
This PR bumps dependency for openclean-notebook to 0.1.7.

